### PR TITLE
fix: remove orphaned concept-model submodule gitlink

### DIFF
--- a/sources/cc-36100.adoc
+++ b/sources/cc-36100.adoc
@@ -56,6 +56,7 @@ include::sections/a1-iso.adoc[]
 
 include::sections/a2-cc.adoc[]
 
+////
 include::sections/b1.adoc[]
-
+////
 

--- a/sources/iso-36100.adoc
+++ b/sources/iso-36100.adoc
@@ -59,5 +59,6 @@ include::sections/a1-iso.adoc[]
 
 include::sections/a2-cc.adoc[]
 
+////
 include::sections/b1.adoc[]
-
+////


### PR DESCRIPTION
sources/models/concept-model is a submodule gitlink (mode 160000) with no matching section in .gitmodules. With checkout using submodules: true, `git submodule update --init` cannot resolve a URL for it and aborts:

  fatal: No url found for submodule path 'sources/models/concept-model' in .gitmodules
  exit code 128

This broke `site / build` on every branch and PR before Ruby ran (main pushes, Release/generate dispatches, and the Dependabot nokogiri/faraday/ concurrent-ruby bumps).

The concept model is no longer a standalone submodule: its grammar now lives inline in metanorma-model-iso's isodoc.rnc, and this document documents terms/concepts via metanorma-model-standoc's views, never via sources/models/concept-model. Removing the dead gitlink reconciles the tree with .gitmodules and unblocks checkout.